### PR TITLE
Run cargo without `--locked`

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -29,10 +29,10 @@ runs:
     - name: Build pijul
       shell: bash
       run: |
-        cargo install pijul --version ${{ inputs.version }} --root . --locked
+        cargo install pijul --version ${{ inputs.version }} --root .
         cp bin/pijul.exe pijul.exe
     - name: Build pijul-with-git
       shell: bash
       run: |
-        cargo install pijul --version ${{ inputs.version }} --root . --locked --features git
+        cargo install pijul --version ${{ inputs.version }} --root . --features git
         cp bin/pijul.exe pijul-with-git.exe


### PR DESCRIPTION
This seems to fix build errors on recent versions - I assume the old lockfile was including `thrussh-libsodium` version `0.2.2` or earlier, which enables `use-pkg-config` on `libsodium-sys`, even when compiling on MSVC.