### PR TITLE
Build with static MSVC

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,11 +11,12 @@ runs:
     - name: Set up environment
       shell: bash
       run: |
+        echo "RUSTFLAGS=-Ctarget-feature=+crt-static" | tee -a "$GITHUB_ENV"
         echo "CARGO_TERM_COLOR=always" | tee -a "$GITHUB_ENV"
-        echo "VCPKG_DEFAULT_TRIPLET=x64-windows-static-md" | tee -a "$GITHUB_ENV"
+        echo "VCPKG_DEFAULT_TRIPLET=x64-windows-static" | tee -a "$GITHUB_ENV"
         echo "VCPKG_INSTALLED_DIR=${{ github.workspace }}/vcpkg_installed" | tee -a "$GITHUB_ENV"
-        echo "LIB=${{ github.workspace }}/vcpkg_installed/x64-windows-static-md/lib" | tee -a "$GITHUB_ENV"
-        echo "OPENSSL_DIR=${{ github.workspace }}/vcpkg_installed/x64-windows-static-md" | tee -a "$GITHUB_ENV"
+        echo "LIB=${{ github.workspace }}/vcpkg_installed/x64-windows-static/lib" | tee -a "$GITHUB_ENV"
+        echo "OPENSSL_DIR=${{ github.workspace }}/vcpkg_installed/x64-windows-static" | tee -a "$GITHUB_ENV"
         echo "CARGO_TARGET_DIR=${{ github.workspace }}/cargo_target" | tee -a "$GITHUB_ENV"
     - uses: lukka/run-vcpkg@v11
       with:

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -19,7 +19,7 @@ runs:
         echo "CARGO_TARGET_DIR=${{ github.workspace }}/cargo_target" | tee -a "$GITHUB_ENV"
     - uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: "f6a5d4e8eb7476b8d7fc12a56dff300c1c986131"
+        vcpkgGitCommitId: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
         runVcpkgInstall: true
     - name: Cache Cargo target dir
       uses: actions/cache@v3

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -20,11 +20,11 @@ jobs:
         uses: ./.github/actions/build
         with:
           version: ${{ inputs.version }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pijul.exe
           path: pijul.exe
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pijul-with-git.exe
           path: pijul-with-git.exe


### PR DESCRIPTION
I noticed while testing on a fresh Windows installation that the binary silently depends on MSVC, and at least in Powershell it silently fails and exits when run. This PR changes the vcpkg target from `x64-windows-static-md` (static libraries, dynamic CRT) to just `x86-windows-static` (static everything), which in my testing has fixed the issue. The artifact size was only increased by ~0.1MB, so I don't think that's much of a concern.

Ideally Pijul would set the RUSTFLAGS in `.cargo/config.toml` directly, as done by [ripgrep](https://github.com/BurntSushi/ripgrep/blob/master/.cargo/config.toml), but that will hopefully be fixed in a future release :)